### PR TITLE
stabilize TestMethod ordering

### DIFF
--- a/src/main/java/com/tupilabs/testng/parser/Class.java
+++ b/src/main/java/com/tupilabs/testng/parser/Class.java
@@ -25,7 +25,7 @@ package com.tupilabs.testng.parser;
 
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -48,7 +48,7 @@ public class Class implements Serializable {
 	 */
 	public Class() {
 		super();
-		this.testMethods = Collections.synchronizedSet(new HashSet<TestMethod>());
+		this.testMethods = Collections.synchronizedSet(new LinkedHashSet<TestMethod>());
 	}
 	/**
 	 * Retrieves the name.

--- a/src/test/java/com/tupilabs/testng/parser/TestTestNGParser.java
+++ b/src/test/java/com/tupilabs/testng/parser/TestTestNGParser.java
@@ -114,4 +114,30 @@ public class TestTestNGParser extends TestCase {
 
 	}
 
+	private Suite parseResourceSuite(String name) {
+		File file = new File(TestTestNGParser.class.getResource(name).getFile());
+		Suite suite = null;
+		try {
+			suite = this.parser.parse(file);
+		} catch (ParserException e) {
+			fail("Failed to parse testng file '" + file + "': " + e.getMessage());
+		}
+		return suite;
+	}
+
+	public void testMethodIterationOrder() {
+
+		Suite suite = parseResourceSuite("testng-results-ordered.xml");
+
+		String last = null;
+		for (TestMethod method : suite.getTests().get(0).getClasses().get(0).getTestMethods()) {
+			String testName = method.getName();
+			if (last != null) {
+				assertTrue("test not in correct order:" + testName,
+						last.compareTo(method.getName()) < 0);
+			}
+			last = testName;
+		}
+		assertNotNull("did not find any testMethods..", last);
+	}
 }

--- a/src/test/resources/com/tupilabs/testng/parser/testng-results-ordered.xml
+++ b/src/test/resources/com/tupilabs/testng/parser/testng-results-ordered.xml
@@ -1,0 +1,22 @@
+<testng-results>
+  <reporter-output>
+  </reporter-output>
+  <suite name="Command line suite" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z">
+    <groups>
+    </groups>
+    <test name="Command line test" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z">
+      <class name="br.eti.kinoshita.Test1">
+        <test-method status="PASS" signature="test001()" name="test001" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z"></test-method>
+        <test-method status="PASS" signature="test002()" name="test002" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z"></test-method>
+        <test-method status="PASS" signature="test003()" name="test003" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z"></test-method>
+        <test-method status="PASS" signature="test004()" name="test004" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z"></test-method>
+        <test-method status="PASS" signature="test005()" name="test005" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z"></test-method>
+        <test-method status="PASS" signature="test006()" name="test006" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z"></test-method>
+        <test-method status="PASS" signature="test007()" name="test007" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z"></test-method>
+        <test-method status="PASS" signature="test008()" name="test008" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z"></test-method>
+        <test-method status="PASS" signature="test009()" name="test009" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z"></test-method>
+        <test-method status="PASS" signature="test010()" name="test010" duration-ms="0" started-at="2010-11-17T13:31:41Z" finished-at="2010-11-17T13:31:41Z"></test-method>
+      </class>
+    </test>
+  </suite>
+</testng-results>


### PR DESCRIPTION
added test for stable ordering of TestMethods and changed Set implementation to LinkedHashSet to allow it to pass.